### PR TITLE
Add support for IronFox Nightly

### DIFF
--- a/composeApp/src/androidMain/res/xml/autofill_service_config.xml
+++ b/composeApp/src/androidMain/res/xml/autofill_service_config.xml
@@ -87,6 +87,7 @@
     <compatibility-package android:name="org.codeaurora.swe.browser" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="org.gnu.icecat" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="org.ironfoxoss.ironfox" android:maxLongVersionCode="10000000000" />
+    <compatibility-package android:name="org.ironfoxoss.ironfox.nightly" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="org.mozilla.fenix" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="org.mozilla.fenix.nightly" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="org.mozilla.fennec_aurora" android:maxLongVersionCode="10000000000" />


### PR DESCRIPTION
As of https://github.com/ironfox-oss/IronFox/commit/a2c7570bdc4dc824ec3b66f4ec12f9678cbe7de9, we're now using a separate package ID for Nightly builds. This adds support for IronFox Nightly.